### PR TITLE
Hotfix - duplicated unify, missing libglib in docker and killing cellery pids

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -7,6 +7,8 @@ RUN echo 'Acquire::http::Pipeline-Depth 0;\nAcquire::http::No-Cache true;\nAcqui
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* \
     && apt-get update --fix-missing \
     && apt-get install -y \
+        libglib2.0-0 \
+        libglib2.0-dev \
         libgl1-mesa-glx \
         poppler-utils \
         libmagic1 \

--- a/dev.gpu.Dockerfile
+++ b/dev.gpu.Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
     python3-pip \
     libgl1 \
     libglib2.0-0 \
+    libglib2.0-dev \
     curl \
     gnupg2 \
     ca-certificates \

--- a/run.sh
+++ b/run.sh
@@ -53,7 +53,18 @@ echo "Your ENV settings loaded from .env.localhost file: "
 printenv
 
 CELERY_BIN="$(pwd)/.venv/bin/celery"
-CELERY_PID=$(pgrep -f "$CELERY_BIN")
+CELERY_PIDS=$(pgrep -f "$CELERY_BIN")
+
+if [ -n "$CELERY_PIDS" ]; then
+  echo "Killing existing Celery processes from $CELERY_BIN with PIDs:"
+  echo "$CELERY_PIDS"
+  for PID in $CELERY_PIDS; do
+    kill "$PID" || echo "Failed to kill process with PID: $PID"
+  done
+else
+  echo "No running Celery process found."
+fi
+
 REDIS_PORT=6379 # will move it to .envs in near future
 
 if lsof -i :$REDIS_PORT | grep LISTEN >/dev/null; then

--- a/text_extract_api/files/file_formats/file_format.py
+++ b/text_extract_api/files/file_formats/file_format.py
@@ -178,15 +178,6 @@ class FileFormat:
         """
         return {}
 
-    def unify(self) -> Type["FileFormat"]:
-        """
-        Converts the file to a universal type for that format (e.g., JPEG from png, bmp, tiff, etc.).
-        Default implementation returns a new instance of the current format.
-
-        :return: Unified format as a new self instance.
-        """
-        return self
-
     @classmethod
     def default_iterator_file_format(cls) -> Type["FileFormat"]:
         if not cls.is_pageable():


### PR DESCRIPTION

**Missing libglib:**

```fastapi_app-1    | ImportError: libgthread-2.0.so.0: cannot open shared object file: No such file or directory```

It's required by EasyOCR. I just checked the logs, and during my full tests, I used the local environment twice instead of using the docker in second approach. I manually tested the docker cpu but only with the default strategy (llama) to ensure the basics were working correctly.

**Duplicated `unify` method in the `file_format` class.** 

Python simply overrides it, but I wanted to clean it up as soon as possible because it could be really misleading.


**Killing celery pids after re-run**

Only one part was committed. I've got the rest in my local history so i simply reverted it - now it's working as intended.