### PR TITLE
chore: rename clean-cache to clear-cache in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,9 @@ run-docker-gpu:
 clean:
 	@echo "Cleaning project..."; \
 	docker-compose down -v; \
-	$(MAKE) clean-cache
+	$(MAKE) clear-cache
 
 .PHONY: clean-python-cache
-clean-cache:
+clear-cache:
 	find . -type d -name '__pycache__' -exec rm -rf {} + && find . -type f -name '*.pyc' -delete
 


### PR DESCRIPTION
Rename the command name according to the description of `make clear-cache` on line 21 of the Makefile.

https://github.com/CatchTheTornado/text-extract-api/blob/536802e89386ac6bd18f9afdd42f863c5da37873/Makefile#L13-L22