### PR TITLE
fix(docker): use libgl1 on Debian/Ubuntu (trixie-compatible)

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* \
     && apt-get install -y \
         libglib2.0-0 \
         libglib2.0-dev \
-        libgl1-mesa-glx \
+        libgl1 \
         poppler-utils \
         libmagic1 \
         libmagic-dev \

--- a/dev.gpu.Dockerfile
+++ b/dev.gpu.Dockerfile
@@ -43,7 +43,7 @@ RUN echo 'Acquire::http::Pipeline-Depth 0;\nAcquire::http::No-Cache true;\nAcqui
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* \
     && apt-get update --fix-missing \
     && apt-get install -y \
-        libgl1-mesa-glx \
+        libgl1 \
         poppler-utils \
         libpoppler-cpp-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #126

On Debian trixie, libgl1-mesa-glx is obsolete and has no installation candidate. Switch to libgl1 to restore builds.

Changes:
- dev.Dockerfile: replace libgl1-mesa-glx -> libgl1
- dev.gpu.Dockerfile: use libgl1 for parity with CPU image

Outcome: `docker-compose up --build` no longer fails during apt install step on trixie-based images.